### PR TITLE
Output json path not always contains dirname

### DIFF
--- a/voc2coco.py
+++ b/voc2coco.py
@@ -130,7 +130,8 @@ def convert(xml_files, json_file):
         cat = {"supercategory": "none", "id": cid, "name": cate}
         json_dict["categories"].append(cat)
 
-    os.makedirs(os.path.dirname(json_file), exist_ok=True)
+    if os.path.dirname(json_file):
+        os.makedirs(os.path.dirname(json_file), exist_ok=True)
     json_fp = open(json_file, "w")
     json_str = json.dumps(json_dict)
     json_fp.write(json_str)


### PR DESCRIPTION
Without this patch `python3 ./voc2coco.py ../Annotations/ tmp.json` will raise an exception:

```
Number of xml files: 1750
Traceback (most recent call last):
  File "./voc2coco.py", line 153, in <module>
    convert(xml_files, args.json_file)
  File "./voc2coco.py", line 133, in convert
    os.makedirs(os.path.dirname(json_file), exist_ok=True)
  File "/usr/lib/python3.6/os.py", line 220, in makedirs
    mkdir(name, mode)
FileNotFoundError: [Errno 2] No such file or directory: ''
```