### PR TITLE
Update voc2coco.py

### DIFF
--- a/voc2coco.py
+++ b/voc2coco.py
@@ -105,10 +105,10 @@ def convert(xml_files, json_file):
                 categories[category] = new_id
             category_id = categories[category]
             bndbox = get_and_check(obj, "bndbox", 1)
-            xmin = int(get_and_check(bndbox, "xmin", 1).text) - 1
-            ymin = int(get_and_check(bndbox, "ymin", 1).text) - 1
-            xmax = int(get_and_check(bndbox, "xmax", 1).text)
-            ymax = int(get_and_check(bndbox, "ymax", 1).text)
+            xmin = int(float(get_and_check(bndbox, "xmin", 1).text)) - 1
+            ymin = int(float(get_and_check(bndbox, "ymin", 1).text)) - 1
+            xmax = int(float(get_and_check(bndbox, "xmax", 1).text))
+            ymax = int(float(get_and_check(bndbox, "ymax", 1).text))
             assert xmax > xmin
             assert ymax > ymin
             o_width = abs(xmax - xmin)


### PR DESCRIPTION
I encountered the error below so I fixed it.

`ValueError: invalid literal for int() with base 10: '45.70000076293945'`

<img width="744" alt="스크린샷 2021-11-25 오후 10 25 23" src="https://user-images.githubusercontent.com/36429399/143449541-edfc248e-575f-48d8-989e-f387b1d64478.png">
